### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/NikolaiIvanov/60e1a9d0-a257-4f63-bd89-5f6a465ffef4/ffaca637-bdb9-4d7f-b6b8-3b1ecdbd4dbe/_apis/work/boardbadge/d0ec62d6-da3e-42fd-b948-255cf3e1f9b1)](https://dev.azure.com/NikolaiIvanov/60e1a9d0-a257-4f63-bd89-5f6a465ffef4/_boards/board/t/ffaca637-bdb9-4d7f-b6b8-3b1ecdbd4dbe/Microsoft.RequirementCategory)
 # dotnet-nproducts
 Web application and Web API for Northwind products management.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/NikolaiIvanov/60e1a9d0-a257-4f63-bd89-5f6a465ffef4/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.